### PR TITLE
Move Commit Hash to File

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   YES_DIFF_LABEL: changes-website
+  DIFF_EXCLUDE_PAT: "commit.txt"
 
 jobs:
   build:
@@ -51,7 +52,7 @@ jobs:
       - name: Generate diff
         id: diff
         run: |
-          diff -r build-base build-head > diff.txt \
+          diff -r --exclude=${{ env.DIFF_EXCLUDE_PAT }} build-base build-head > diff.txt \
             && echo "diff=no" >> "$GITHUB_OUTPUT" \
             || if [ $? -eq 1 ]; then echo "diff=yes" >> "$GITHUB_OUTPUT"; else exit $?; fi
       - name: Archive diff results

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ publish:
 	"$(PELICAN)" "$(INPUTDIR)" -o "$(OUTPUTDIR)" -s "$(PUBLISHCONF)" $(PELICANOPTS)
 #	$(MAKE) purify
 	$(MAKE) icons
+	$(MAKE) $(OUTPUTDIR)/commit.txt
 
 ssh_upload: publish
 	if [ -f ~/.scripts/krbSetup_MIT ]; then  ~/.scripts/krbSetup_MIT; fi
@@ -107,6 +108,12 @@ icons: $(OUTPUTDIR)/icon-80.png $(OUTPUTDIR)/icon-120.png $(OUTPUTDIR)/icon-180.
 
 $(OUTPUTDIR)/icon-%.png: $(ICON_SVG)
 	convert -density 2400 -resize $*x$* $<  $@
+
+# note the commit hash
+.PHONY: $(OUTPUTDIR)/commit.txt
+
+$(OUTPUTDIR)/commit.txt:
+	python -c "import sys; import git; sys.stdout.write(git.Repo().head.object.hexsha)" >  $@
 
 # run purify
 .PHONY: purify

--- a/publishconf.py
+++ b/publishconf.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import git
 import datetime
 sys.path.append(os.curdir)
 from pelicanconf import *
@@ -16,10 +15,6 @@ DELETE_OUTPUT_DIRECTORY = True
 
 # Google Analytics
 GOGGLE_DEBUG_MODE = False
-
-# source code link (with hash)
-sha = git.Repo(search_parent_directories=True).head.object.hexsha
-SOURCE_CODE_URL= SOURCE_CODE_URL+'/tree/'+sha
 
 # copy right date
 COPY_DATE=datetime.date.today().strftime('%Y')

--- a/publishconf_dev.py
+++ b/publishconf_dev.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import git
 import datetime
 sys.path.append(os.curdir)
 from pelicanconf import *
@@ -16,10 +15,6 @@ DELETE_OUTPUT_DIRECTORY = True
 
 # Google Analytics
 GOGGLE_DEBUG_MODE = True
-
-# source code link (with hash)
-sha = git.Repo(search_parent_directories=True).head.object.hexsha
-SOURCE_CODE_URL= SOURCE_CODE_URL+'/tree/'+sha
 
 # copy right date
 COPY_DATE=datetime.date.today().strftime('%Y')


### PR DESCRIPTION
Rather than showing up in the source link, move commit hash to commit.txt