### PR TITLE
Turn off pelican generated index

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -29,6 +29,7 @@ PAGE_SAVE_AS = '{slug}/index.html'
 AUTHOR_SAVE_AS = ''
 TAG_SAVE_AS = ''
 ARCHIVES_SAVE_AS = ''
+INDEX_SAVE_AS = ''
 
 STATIC_PATHS = ['images','static','files']
 ARTICLE_PATHS  = ['posts']


### PR DESCRIPTION
Make sure Pelican doesn't generate an `index.html`, which is then overwritten.