### PR TITLE
Canonical URL cleanup

### DIFF
--- a/content/theme/welcome.html
+++ b/content/theme/welcome.html
@@ -12,13 +12,13 @@
     <h2>For more:</h2>
     <ul>
       <li>
-        <p><a href="{{ SITEURL }}/publications">Publications</a> for a list of my presentations and publications.</p>
+        <p><a href="{{ SITEURL }}/publications/">Publications</a> for a list of my presentations and publications.</p>
       </li>
       <li>
-        <p><a href="{{ SITEURL }}/education">Education</a> for my academic degrees.</p>
+        <p><a href="{{ SITEURL }}/education/">Education</a> for my academic degrees.</p>
       </li>
       <li>
-        <p><a href="{{ SITEURL }}/posts">Posts</a> for recent posts on my work and my hobbies.</p>
+        <p><a href="{{ SITEURL }}/posts/">Posts</a> for recent posts on my work and my hobbies.</p>
       </li>
       <li>
         <p><a href="/files/Declan Gaylo - Resume.pdf">Resume <i class="bi bi-file-earmark-pdf"></i></a>.</p>

--- a/mytheme/templates/error.html
+++ b/mytheme/templates/error.html
@@ -3,6 +3,9 @@
 {% block breadcrumb %}
 {% endblock %}
 
+{% block canonical_rel %}
+{% endblock %}
+
 {% block head %}
 {{ super() }}
 {% if GOOGLE_GLOBAL_SITE_TAG %}

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -18,12 +18,12 @@ AUTHOR_FEED_ATOM = None
 AUTHOR_FEED_RSS = None
 
 # Setup URLS
-CATEGORY_URL = '{slug}'
-CATEGORY_SAVE_AS  = '{slug}/index.html'
-ARTICLE_URL = '{category}/{slug}'
-ARTICLE_SAVE_AS = '{category}/{slug}/index.html'
-PAGE_URL = '{slug}'
-PAGE_SAVE_AS = '{slug}/index.html'
+CATEGORY_URL = '{slug}/'
+CATEGORY_SAVE_AS  = CATEGORY_URL+'index.html'
+ARTICLE_URL = '{category}/{slug}/'
+ARTICLE_SAVE_AS = ARTICLE_URL+'index.html'
+PAGE_URL = '{slug}/'
+PAGE_SAVE_AS = PAGE_URL+'index.html'
 
 # Defualts not to generate
 AUTHOR_SAVE_AS = ''

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -109,8 +109,8 @@ BANNER_ALL_PAGES = False
 DISPLAY_PAGES_ON_MENU = False
 DEFAULT_CATEGORY  = "Posts"
 MENUITEMS = (
-    ('Publications', 'publications'),
-    ('Education', 'education'),
+    ('Publications', 'publications/'),
+    ('Education', 'education/'),
 )
 
 DISABLE_SIDEBAR_TITLE_ICONS = True


### PR DESCRIPTION
- Add trailing `/` to links
- Removed (wrong) canonical from error pages
- Cleaner URL setup in `pelicanconf.py`