### PR TITLE
Sitemap update

### DIFF
--- a/content/pages/education.html
+++ b/content/pages/education.html
@@ -3,6 +3,7 @@
         <title>Education</title>
         <meta name="modified" content="2023-11-05 00:00" />
         <meta name="slug" content="education" />
+        <meta name="ChangeFreq" content="yearly" />
     </head>
     <body>
         <div class="row py-3">

--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -4,6 +4,8 @@ save_as: index.html
 url:
 template: welcome
 modified: 2023-12-29 00:00
+ChangeFreq: yearly
+Priority: 0.9
 
 My name is Declan Gaylo and I'm a naval architect working on my PhD in Hydrodynamics at MIT. 
 My research focuses on understanding the complex dynamics of turbulence near the free surface, such as in the wake of a vessel, and how it affects the creation and evolution of bubble clouds under the surface.

--- a/content/pages/publications.md
+++ b/content/pages/publications.md
@@ -1,7 +1,8 @@
 Title: Publications
 slug: publications
 modified: 2023-11-24 00:00
-
+ChangeFreq: monthly
+Priority: 0.7
 
 ## Journal Papers
 

--- a/content/posts/hiking4Ks.md
+++ b/content/posts/hiking4Ks.md
@@ -1,6 +1,8 @@
 Title: Hiking New Hampshire's 4,000 Footers
 Date: 2022-09-17 11:59
 slug: hiking4ks
+ChangeFreq: monthly
+Priority: 0.3
 description: There are 48 mountains in New Hampshire's White Mountains over 4,000 feet. On this page I track my progress hiking all of them.
 graphic: images/hiking4Ks.jpg
 graphicAlt: Declan hiking in the White Mounatains

--- a/content/posts/undergradthesis.md
+++ b/content/posts/undergradthesis.md
@@ -1,6 +1,8 @@
 Title: Pressure Effects of Transom Lift Devices on Prismatic Planing Hulls
 slug: undergradthesis
 date: 2019-06-28 00:00
+ChangeFreq: never
+Priority: 0.3
 description: My undergraduate thesis was on trim tabs and interceptors for high speed planing craft. This post provides an overview of the work.
 graphic: images/undergradthesis.jpg
 graphicAlt: The model hull fittes with pressure sensors

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -48,8 +48,8 @@ ADD_CSS_CLASSES_TO_ARTICLE = {
 SITEMAP = {
     "format": "xml",
     "changefreqs": {
-        "articles": "monthly",
-        "indexes": "daily",
+        "articles": "never",
+        "indexes": "monthly",
         "pages": "monthly"
     },
     "exclude": ["index"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ mdurl==0.1.2
 ordered-set==4.1.0
 pelican==4.9.1
 pelican-add-css-classes==1.0.4
-pelican-sitemap==1.1.0
+pelican-sitemap==1.2.0
 pelican-webassets==2.0.0
 Pygments==2.17.2
 python-dateutil==2.8.2


### PR DESCRIPTION
- Bump pelican-sitemap from 1.1.0 to 1.2.0
- Set `changefreqs` and `Priority` manually for many pages 
  - made possible by pelican-plugins/sitemap/pull/30
- Changed defaults for `changefreq`